### PR TITLE
Dates: Extend author-reviewer discussion

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -118,12 +118,14 @@ conference:
     - name: Author-Reviewer discussion period
       type: review
       date: 27 November 2024
-      enddate: 4 December 2024
+      enddate: 9 December 2024
       important: true
+      endold: 4 December 2024
     - name: Author rebuttals due
       type: submission
-      date: 5 December 2024
+      date: 10 December 2024
       important: true
+      old: 5 December 2024
     - name: Reviewer-AC discussion period
       type: review
       date: 5 December 2024

--- a/_includes/listdates.html
+++ b/_includes/listdates.html
@@ -33,16 +33,34 @@ Dates may be subject to change. All dates are Anywhere on Earth (AoE), end of da
             {% if site.TZ %} ({{ site.TZ }}){% endif %}
           </time>
         {% elsif deadline.date %}
+          {% if deadline.old %}
+            <s>
+              <time datetime="{{ deadline.old }}">
+                {{ deadline.old | date: datefmt }}
+              </time>
+            </s>
+            &nbsp;extended to
+          {% endif %}
           <time datetime="{{ deadline.date }}">
             {{ deadline.date | date: datefmt }}
           </time>
           {% if deadline.enddate %}
             -
+            {% if deadline.endold %}
+              <s>
+                <time datetime="{{ deadline.endold }}">
+                  {{ deadline.endold | date: datefmt }}
+                </time>
+              </s>
+              &nbsp;extended to
+            {% endif %}
             <time datetime="{{ deadline.enddate }}">
               {{ deadline.enddate | date: datefmt }}
             </time>
           {% endif %}
         {% endif %}
+
+        {% if deadline.suffix %}{{ deadline.suffix }}{% endif %}
 
         {% if deadline.important %}</strong>{% endif %}
         {% if endunix < nowunix %}</s>{% endif %}


### PR DESCRIPTION
- add keywords "old" and "endold", which can be used to extend deadlines (they list the date before the extension)
- update dates